### PR TITLE
Updated accessors.py

### DIFF
--- a/xwrf/accessors.py
+++ b/xwrf/accessors.py
@@ -174,7 +174,8 @@ class WRFDatasetAccessor(WRFAccessor):
         )
         new_data_vars = {}
         for var_name, var_data in self.xarray_obj.data_vars.items():
-            if this_staggered_dims := set(var_data.dims).intersection(staggered_dims):
+            this_staggered_dims = set(var_data.dims).intersection(staggered_dims)
+            if this_staggered_dims:
                 # Found a staggered dim
                 # TODO: should we raise an error if somehow end up with more than just one
                 # staggered dim, or just pick one from the set like below?


### PR DESCRIPTION
Just did some small assignment task to remove this small error of walrus operator(:=) which will make the module xwrf run even in unupdated versions of python solving the import error

<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
